### PR TITLE
notification fun time

### DIFF
--- a/PaWPal/PaWPal/AppDelegate.swift
+++ b/PaWPal/PaWPal/AppDelegate.swift
@@ -45,6 +45,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     if let dailyCount = value?["dailySurveyCount"] { AppState.sharedInstance.dailySurveyCount = (dailyCount as! NSNumber).integerValue }
                     if let totalCount = value?["totalSurveyCount"] { AppState.sharedInstance.totalSurveyCount = (totalCount as! NSNumber).integerValue }
                     
+                    NotificationScheduler.resetDailyCountIfNecessary()
                     NotificationScheduler.scheduleNotificationsOnSignIn()
                     }
                 )

--- a/PaWPal/PaWPal/AppDelegate.swift
+++ b/PaWPal/PaWPal/AppDelegate.swift
@@ -45,7 +45,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     if let dailyCount = value?["dailySurveyCount"] { AppState.sharedInstance.dailySurveyCount = (dailyCount as! NSNumber).integerValue }
                     if let totalCount = value?["totalSurveyCount"] { AppState.sharedInstance.totalSurveyCount = (totalCount as! NSNumber).integerValue }
                     
+                    // will reset the daily survey count if we the closestNotification is the morning notification and the current time is past that
                     NotificationScheduler.resetDailyCountIfNecessary()
+                    // will schedule the morning notifications for the coming week
                     NotificationScheduler.scheduleNotificationsOnSignIn()
                     }
                 )

--- a/PaWPal/PaWPal/AppDelegate.swift
+++ b/PaWPal/PaWPal/AppDelegate.swift
@@ -42,10 +42,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     if let sleepTime = value?["sleepTime"] { AppState.sharedInstance.sleepTime = sleepTime as? String }
                     if let closestNotification = value?["closestScheduledNotification"] { AppState.sharedInstance.closestScheduledNotification = closestNotification as? String }
                     if let furthestNotification = value?["furthestScheduledNotification"] { AppState.sharedInstance.furthestScheduledNotification = furthestNotification as? String }
+                    
+                    NotificationScheduler.scheduleNotificationsOnSignIn()
                     }
                 )
-                
-                NotificationScheduler.scheduleNotificationsOnSignIn()
                 
                 return true
             }

--- a/PaWPal/PaWPal/AppDelegate.swift
+++ b/PaWPal/PaWPal/AppDelegate.swift
@@ -45,6 +45,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     }
                 )
                 
+                NotificationScheduler.scheduleNotificationsOnSignIn()
+                
                 return true
             }
         }

--- a/PaWPal/PaWPal/AppDelegate.swift
+++ b/PaWPal/PaWPal/AppDelegate.swift
@@ -42,6 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     if let sleepTime = value?["sleepTime"] { AppState.sharedInstance.sleepTime = sleepTime as? String }
                     if let closestNotification = value?["closestScheduledNotification"] { AppState.sharedInstance.closestScheduledNotification = closestNotification as? String }
                     if let furthestNotification = value?["furthestScheduledNotification"] { AppState.sharedInstance.furthestScheduledNotification = furthestNotification as? String }
+                    if let dailyCount = value?["dailySurveyCount"] { AppState.sharedInstance.dailySurveyCount = (dailyCount as! NSNumber).integerValue }
                     
                     NotificationScheduler.scheduleNotificationsOnSignIn()
                     }

--- a/PaWPal/PaWPal/AppDelegate.swift
+++ b/PaWPal/PaWPal/AppDelegate.swift
@@ -43,6 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     if let closestNotification = value?["closestScheduledNotification"] { AppState.sharedInstance.closestScheduledNotification = closestNotification as? String }
                     if let furthestNotification = value?["furthestScheduledNotification"] { AppState.sharedInstance.furthestScheduledNotification = furthestNotification as? String }
                     if let dailyCount = value?["dailySurveyCount"] { AppState.sharedInstance.dailySurveyCount = (dailyCount as! NSNumber).integerValue }
+                    if let totalCount = value?["totalSurveyCount"] { AppState.sharedInstance.totalSurveyCount = (totalCount as! NSNumber).integerValue }
                     
                     NotificationScheduler.scheduleNotificationsOnSignIn()
                     }

--- a/PaWPal/PaWPal/AppState.swift
+++ b/PaWPal/PaWPal/AppState.swift
@@ -23,5 +23,6 @@ class AppState: NSObject {
     var signedIn = false
     var closestScheduledNotification: String?
     var furthestScheduledNotification: String?
+    var dailySurveyCount = 0
     var databaseRef = FIRDatabase.database().reference()
 }

--- a/PaWPal/PaWPal/AppState.swift
+++ b/PaWPal/PaWPal/AppState.swift
@@ -24,6 +24,7 @@ class AppState: NSObject {
     var closestScheduledNotification: String?
     var furthestScheduledNotification: String?
     var dailySurveyCount = 0
+    var totalSurveyCount = 0
     var databaseRef = FIRDatabase.database().reference()
     var surveyList = ["where": "",
                       "activity": "",

--- a/PaWPal/PaWPal/Base.lproj/Main.storyboard
+++ b/PaWPal/PaWPal/Base.lproj/Main.storyboard
@@ -466,23 +466,23 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Sleep" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fdX-Lh-4Nm">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Sleep" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fdX-Lh-4Nm">
                                 <rect key="frame" x="20" y="196" width="560" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Wake" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="b6s-DV-WMD">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Wake" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="b6s-DV-WMD">
                                 <rect key="frame" x="20" y="121" width="560" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wake Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bdQ-Pj-HTo">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Wake Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bdQ-Pj-HTo">
                                 <rect key="frame" x="20" y="91" width="85" height="20"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sleep Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I8h-pL-SYC">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Sleep Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I8h-pL-SYC">
                                 <rect key="frame" x="20" y="166" width="86" height="20"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>

--- a/PaWPal/PaWPal/DatabaseController.swift
+++ b/PaWPal/PaWPal/DatabaseController.swift
@@ -60,6 +60,7 @@ class DatabaseController {
                 if let sleepTime = value?["sleepTime"] { AppState.sharedInstance.sleepTime = sleepTime as? String }
                 if let closestNotification = value?["closestScheduledNotification"] { AppState.sharedInstance.closestScheduledNotification = closestNotification as? String }
                 if let furthestNotification = value?["furthestScheduledNotification"] { AppState.sharedInstance.furthestScheduledNotification = furthestNotification as? String }
+                if let dailyCount = value?["dailySurveyCount"] { AppState.sharedInstance.dailySurveyCount = Int(dailyCount as! String)! }
                 }
             )
             
@@ -101,6 +102,10 @@ class DatabaseController {
     static func getUid() -> String {
         if let uid = AppState.sharedInstance.uid { return uid }
         else { return "" }
+    }
+    
+    static func getDailySurveyCount() -> Int {
+        return AppState.sharedInstance.dailySurveyCount
     }
     
     //list of functions to set user info
@@ -146,4 +151,13 @@ class DatabaseController {
         AppState.sharedInstance.furthestScheduledNotification = date
     }
     
+    static func incrementDailySurveyCount() {
+        AppState.sharedInstance.databaseRef.child("/users/\(getUid())/dailySurveyCount").setValue(getDailySurveyCount()+1)
+        AppState.sharedInstance.dailySurveyCount += 1
+    }
+    
+    static func resetDailySurveyCount() {
+        AppState.sharedInstance.databaseRef.child("/users/\(getUid())/dailySurveyCount").setValue(0)
+        AppState.sharedInstance.dailySurveyCount = 0
+    }
 }

--- a/PaWPal/PaWPal/DatabaseController.swift
+++ b/PaWPal/PaWPal/DatabaseController.swift
@@ -61,6 +61,7 @@ class DatabaseController {
                 if let closestNotification = value?["closestScheduledNotification"] { AppState.sharedInstance.closestScheduledNotification = closestNotification as? String }
                 if let furthestNotification = value?["furthestScheduledNotification"] { AppState.sharedInstance.furthestScheduledNotification = furthestNotification as? String }
                 if let dailyCount = value?["dailySurveyCount"] { AppState.sharedInstance.dailySurveyCount = Int(dailyCount as! String)! }
+                if let totalCount = value?["totalSurveyCount"] { AppState.sharedInstance.totalSurveyCount = (totalCount as! NSNumber).integerValue }
                 }
             )
             
@@ -132,6 +133,10 @@ class DatabaseController {
         return AppState.sharedInstance.dailySurveyCount
     }
     
+    static func getTotalSurveyCount() -> Int {
+        return AppState.sharedInstance.totalSurveyCount
+    }
+    
     //list of functions to set user info
     static func setEmail(userEmail: String){
         //TODO
@@ -183,5 +188,10 @@ class DatabaseController {
     static func resetDailySurveyCount() {
         AppState.sharedInstance.databaseRef.child("/users/\(getUid())/dailySurveyCount").setValue(0)
         AppState.sharedInstance.dailySurveyCount = 0
+    }
+    
+    static func incrementTotalSurveyCount() {
+        AppState.sharedInstance.databaseRef.child("/users/\(getUid())/totalSurveyCount").setValue(getTotalSurveyCount()+1)
+        AppState.sharedInstance.totalSurveyCount += 1
     }
 }

--- a/PaWPal/PaWPal/DatabaseController.swift
+++ b/PaWPal/PaWPal/DatabaseController.swift
@@ -139,9 +139,8 @@ class DatabaseController {
     
     //list of functions to set user info
     static func setEmail(userEmail: String){
-        //TODO
-        NSUserDefaults.standardUserDefaults().setObject(userEmail, forKey: "userEmail")
-        NSUserDefaults.standardUserDefaults().synchronize()
+        AppState.sharedInstance.databaseRef.child("/users/\(getUid())/userEmail").setValue(userEmail)
+        AppState.sharedInstance.userName = userEmail
     }
     
     static func setPassword(userPassword: String){

--- a/PaWPal/PaWPal/NotificationScheduler.swift
+++ b/PaWPal/PaWPal/NotificationScheduler.swift
@@ -144,7 +144,7 @@ class NotificationScheduler {
         }
         
         if (closestComponents.hour == wakeTimeComponents.hour && closestComponents.minute == wakeTimeComponents.minute+30) {
-            if (nsDate.compare(calendar.dateFromComponents(closestComponents))) {
+            if (nsDate.compare(calendar.dateFromComponents(closestComponents)!) == NSComparisonResult.OrderedDescending) {
                 DatabaseController.resetDailySurveyCount()
             }
         }

--- a/PaWPal/PaWPal/NotificationScheduler.swift
+++ b/PaWPal/PaWPal/NotificationScheduler.swift
@@ -12,6 +12,7 @@ import UIKit
 class NotificationScheduler {
     // Schedule daily 10 AM notifications for a week in advance
     static func scheduleNotificationsOnSignIn() {
+        //clearScheduledNotifications()
         // Computes how many new notifications to schedule
         let calendar = NSCalendar.currentCalendar()
         let nsDate = NSDate()
@@ -88,10 +89,10 @@ class NotificationScheduler {
         // check if the user has already taken all of their surveys for the day
         if (surveyCount < 6) {
             let plusTwoHoursComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
+            plusTwoHoursComponents.hour += 2
             
             // don't ever schedule notifications between 2 am and the morning notification
-            if (plusTwoHoursComponents.hour <= 2 || (plusTwoHoursComponents.hour >= wakeTimeComponents.hour && plusTwoHoursComponents.minute >= wakeTimeComponents.minute)) {
-                plusTwoHoursComponents.hour += 2
+            if (plusTwoHoursComponents.hour < 2 || (plusTwoHoursComponents.hour >= (wakeTimeComponents.hour+2) && plusTwoHoursComponents.minute >= wakeTimeComponents.minute)) {
                 
                 let sleepTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
                 let sleepTime = DatabaseController.getSleepTime().componentsSeparatedByString(":")
@@ -136,6 +137,8 @@ class NotificationScheduler {
     }
     
     static func printScheduledNotifications() {
-        print(UIApplication.sharedApplication().scheduledLocalNotifications)
+        for notification in UIApplication.sharedApplication().scheduledLocalNotifications! as [UILocalNotification] {
+            print(notification.fireDate)
+        }
     }
 }

--- a/PaWPal/PaWPal/NotificationScheduler.swift
+++ b/PaWPal/PaWPal/NotificationScheduler.swift
@@ -67,7 +67,6 @@ class NotificationScheduler {
     }
     
     static func scheduleNextNotificationOfTheDay() {
-        // TODO: call this in the right place
         var scheduledNewNotification = false
         let calendar = NSCalendar.currentCalendar()
         let nsDate = NSDate()

--- a/PaWPal/PaWPal/NotificationScheduler.swift
+++ b/PaWPal/PaWPal/NotificationScheduler.swift
@@ -41,6 +41,7 @@ class NotificationScheduler {
             furthestComponents = currentComponents
         }
         
+        // set the time for the morning notifications based on the user's wake time
         let wakeTime = DatabaseController.getWakeTime()
         let wakeTimeComponents = wakeTime.componentsSeparatedByString(":")
         furthestComponents.hour = Int(wakeTimeComponents[0])!
@@ -107,6 +108,7 @@ class NotificationScheduler {
                 
                 // check if two hours later is before the user's bedtime
                 if ((calendar.dateFromComponents(sleepTimeComponents))?.compare(calendar.dateFromComponents(plusTwoHoursComponents)!) == NSComparisonResult.OrderedDescending) {
+                    // schedule a notification for two hours from current time
                     let notification = UILocalNotification()
                     notification.alertBody = "It's time to take a survey!"
                     notification.alertAction = "open"
@@ -114,6 +116,8 @@ class NotificationScheduler {
                     UIApplication.sharedApplication().scheduleLocalNotification(notification)
                     DatabaseController.setClosestNotification(dateFormatter.stringFromDate(notification.fireDate!))
                     scheduledNewNotification = true
+                    
+                    // leaving print here to help me debug as we continue to work
                     printScheduledNotifications()
                 }
             }
@@ -148,6 +152,7 @@ class NotificationScheduler {
         
         wakeTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: calendar.dateFromComponents(wakeTimeComponents)!)
 
+        // will reset the dailySurveyCount if the closest notification is the morning notification and the current time is past the morning notification
         if (closestComponents.hour == wakeTimeComponents.hour && closestComponents.minute == wakeTimeComponents.minute) {
             if (nsDate.compare(calendar.dateFromComponents(closestComponents)!) == NSComparisonResult.OrderedDescending) {
                 DatabaseController.resetDailySurveyCount()

--- a/PaWPal/PaWPal/NotificationScheduler.swift
+++ b/PaWPal/PaWPal/NotificationScheduler.swift
@@ -74,7 +74,7 @@ class NotificationScheduler {
         
         let currentTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
         
-        let wakeTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
+        var wakeTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
         let wakeTime = DatabaseController.getWakeTime().componentsSeparatedByString(":")
         wakeTimeComponents.hour = Int(wakeTime[0])!
         let wakeTimeMinutesAndAmPm = wakeTime[1].componentsSeparatedByString(" ")
@@ -82,12 +82,14 @@ class NotificationScheduler {
         if (wakeTimeMinutesAndAmPm[1] == "PM") {
             wakeTimeComponents.hour += 12
         }
+        wakeTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: calendar.dateFromComponents(wakeTimeComponents)!)
         
         let surveyCount = DatabaseController.getDailySurveyCount()
         // check if the user has already taken all of their surveys for the day
         if (surveyCount < 6) {
-            let plusTwoHoursComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
+            var plusTwoHoursComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
             plusTwoHoursComponents.hour += 2
+            plusTwoHoursComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: calendar.dateFromComponents(plusTwoHoursComponents)!)
             
             // don't ever schedule notifications between 2 am and the morning notification
             if (plusTwoHoursComponents.hour < 2 || (plusTwoHoursComponents.hour >= (wakeTimeComponents.hour+2) && plusTwoHoursComponents.minute >= wakeTimeComponents.minute)) {
@@ -134,16 +136,19 @@ class NotificationScheduler {
         let closestNotification = AppState.sharedInstance.closestScheduledNotification
         let closestComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: dateFormatter.dateFromString(closestNotification!)!)
         
-        let wakeTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
+        var wakeTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
         let wakeTime = DatabaseController.getWakeTime().componentsSeparatedByString(":")
         wakeTimeComponents.hour = Int(wakeTime[0])!
         let wakeTimeMinutesAndAmPm = wakeTime[1].componentsSeparatedByString(" ")
-        wakeTimeComponents.minute = Int(wakeTimeMinutesAndAmPm[0])! + 30
+        wakeTimeComponents.minute = Int(wakeTimeMinutesAndAmPm[0])!
+        wakeTimeComponents.minute += 30
         if (wakeTimeMinutesAndAmPm[1] == "PM") {
             wakeTimeComponents.hour += 12
         }
         
-        if (closestComponents.hour == wakeTimeComponents.hour && closestComponents.minute == wakeTimeComponents.minute+30) {
+        wakeTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: calendar.dateFromComponents(wakeTimeComponents)!)
+
+        if (closestComponents.hour == wakeTimeComponents.hour && closestComponents.minute == wakeTimeComponents.minute) {
             if (nsDate.compare(calendar.dateFromComponents(closestComponents)!) == NSComparisonResult.OrderedDescending) {
                 DatabaseController.resetDailySurveyCount()
             }
@@ -166,7 +171,7 @@ class NotificationScheduler {
     
     static func getDateFormatter() -> NSDateFormatter {
         let formatter = NSDateFormatter()
-        formatter.dateFormat = "EEE, dd MMM yyy hh:mm:ss +zzzz"
+        formatter.dateFormat = "EEE, dd MMM yyy hh:mm:ss a +zzzz"
         return formatter
     }
 }

--- a/PaWPal/PaWPal/NotificationScheduler.swift
+++ b/PaWPal/PaWPal/NotificationScheduler.swift
@@ -12,7 +12,6 @@ import UIKit
 class NotificationScheduler {
     // Schedule daily 10 AM notifications for a week in advance
     static func scheduleNotificationsOnSignIn() {
-        clearScheduledNotifications()
         // Computes how many new notifications to schedule
         let calendar = NSCalendar.currentCalendar()
         let nsDate = NSDate()
@@ -64,6 +63,68 @@ class NotificationScheduler {
             if (i == 7) {
                 DatabaseController.setFurthestNotification(dateFormatter.stringFromDate(notification.fireDate!))
             }
+        }
+    }
+    
+    static func scheduleNextNotificationOfTheDay() {
+        // TODO: call this in the right place
+        var scheduledNewNotification = false
+        let calendar = NSCalendar.currentCalendar()
+        let nsDate = NSDate()
+        let dateFormatter = NSDateFormatter()
+        dateFormatter.dateFormat = "EEE, dd MMM yyy hh:mm:ss +zzzz"
+        
+        let currentTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
+        
+        let wakeTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
+        let wakeTime = DatabaseController.getWakeTime().componentsSeparatedByString(":")
+        wakeTimeComponents.hour = Int(wakeTime[0])!
+        let wakeTimeMinutesAndAmPm = wakeTime[1].componentsSeparatedByString(" ")
+        wakeTimeComponents.minute = Int(wakeTimeMinutesAndAmPm[0])! + 30
+        if (wakeTimeMinutesAndAmPm[1] == "PM") {
+            wakeTimeComponents.hour += 12
+        }
+        
+        let surveyCount = DatabaseController.getDailySurveyCount()
+        // check if the user has already taken all of their surveys for the day
+        if (surveyCount < 6) {
+            let plusTwoHoursComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
+            
+            // don't ever schedule notifications between 2 am and the morning notification
+            if (plusTwoHoursComponents.hour <= 2 || (plusTwoHoursComponents.hour >= wakeTimeComponents.hour && plusTwoHoursComponents.minute >= wakeTimeComponents.minute)) {
+                plusTwoHoursComponents.hour += 2
+                
+                let sleepTimeComponents = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: nsDate)
+                let sleepTime = DatabaseController.getSleepTime().componentsSeparatedByString(":")
+                sleepTimeComponents.hour = Int(sleepTime[0])!
+                let sleepTimeMinutesAndAmPm = sleepTime[1].componentsSeparatedByString(" ")
+                sleepTimeComponents.minute = Int(sleepTimeMinutesAndAmPm[0])!
+                if (sleepTimeMinutesAndAmPm[1] == "AM") {
+                    sleepTimeComponents.day += 1
+                } else {
+                    sleepTimeComponents.hour += 12
+                }
+                
+                // check if two hours later is before the user's bedtime
+                if ((calendar.dateFromComponents(sleepTimeComponents))?.compare(calendar.dateFromComponents(plusTwoHoursComponents)!) == NSComparisonResult.OrderedDescending) {
+                    let notification = UILocalNotification()
+                    notification.alertBody = "It's time to take a survey!"
+                    notification.alertAction = "open"
+                    notification.fireDate = calendar.dateFromComponents(plusTwoHoursComponents)
+                    UIApplication.sharedApplication().scheduleLocalNotification(notification)
+                    DatabaseController.setClosestNotification(dateFormatter.stringFromDate(notification.fireDate!))
+                    scheduledNewNotification = true
+                    printScheduledNotifications()
+                }
+            }
+        }
+        
+        if (!scheduledNewNotification) {
+            // set closestNotification to the next morning if no next notification was scheduled for the current day
+            if (currentTimeComponents.hour >= wakeTimeComponents.hour) {
+                wakeTimeComponents.day += 1
+            }
+            DatabaseController.setClosestNotification(dateFormatter.stringFromDate(calendar.dateFromComponents(wakeTimeComponents)!))
         }
     }
     

--- a/PaWPal/PaWPal/SurveyPage6ViewController.swift
+++ b/PaWPal/PaWPal/SurveyPage6ViewController.swift
@@ -24,7 +24,6 @@ class SurveyPage6ViewController: UIViewController {
         DatabaseController.incrementDailySurveyCount()
         NotificationScheduler.scheduleNextNotificationOfTheDay()
         
-        
     }
     func displayQuestions(){
         

--- a/PaWPal/PaWPal/SurveyPage6ViewController.swift
+++ b/PaWPal/PaWPal/SurveyPage6ViewController.swift
@@ -20,6 +20,10 @@ class SurveyPage6ViewController: UIViewController {
         
         //submit survey - TODO notification for do you want to submit?
         
+        // stuff that happens when you submit a survey
+        DatabaseController.incrementDailySurveyCount()
+        NotificationScheduler.scheduleNextNotificationOfTheDay()
+        
         
     }
     func displayQuestions(){

--- a/PaWPal/PaWPal/SurveyPage6ViewController.swift
+++ b/PaWPal/PaWPal/SurveyPage6ViewController.swift
@@ -22,6 +22,7 @@ class SurveyPage6ViewController: UIViewController {
         
         // stuff that happens when you submit a survey
         DatabaseController.incrementDailySurveyCount()
+        DatabaseController.incrementTotalSurveyCount()
         NotificationScheduler.scheduleNextNotificationOfTheDay()
         
     }


### PR DESCRIPTION
@tiffanyfong @hmc-cs-asheppard @hmc-cs-dlan 

A bunch of improvements to notifications. I tested as much as I could, but it is kind of hard to test because I don't have  a way to fake the time. But as of right now, what should happen with notifications is this:
- When the app is launched or the user signs in: make sure there are notifications scheduled every morning, 30 minutes after the user's wake time, for the next 7 days
- When the app is launched, I also check if we need to reset the dailySurveyCount. If the next notification is the morning notification, and the current time is after that, I reset the dailySurveyCount
- When the user submits a survey, dailySurveyCount and totalSurveyCount are incremented. Then, if there are two hours left before the user's bed time and the user has not yet taken 6 surveys, I schedule another notification for 2 hours after the current time. Right now I don't schedule any notifications after 2 am, I may relax this as I improve the notifications.
- Right now it is probably possible to get way more notifications than you should and take more than the allotted amount of surveys. This will be fixed when I only make the survey accessible when it is supposed to be.

close #139 close #138 close #133 close #124 close #117 close #115 close #114 
