### PR TITLE
"Refactoring"

### DIFF
--- a/PaWPal/PaWPal/AppState.swift
+++ b/PaWPal/PaWPal/AppState.swift
@@ -45,7 +45,6 @@ class AppState: NSObject {
     var school: String?
     var wakeTime: String?
     var sleepTime: String?
-    var signedIn = false
     var closestScheduledNotification: String?
     var furthestScheduledNotification: String?
     var dailySurveyCount = 0

--- a/PaWPal/PaWPal/SurveyPage1ViewController.swift
+++ b/PaWPal/PaWPal/SurveyPage1ViewController.swift
@@ -20,17 +20,15 @@ class SurveyPage1ViewController: UIViewController, AutoCompleteTextFieldDataSour
     var autoCompleteDictionary = [AutoCompleteTextField: [String]]()
     
     @IBAction func next(sender: UIButton) {
-        // require that text fields be complete
-        guard let textAnswer1 = q1.answerTextField.text
-            where !textAnswer1.isEmpty else {
-                self.displayAlert("Hello", message: "Please fill in all required fields :)", handler: nil)
-                return
+        // check for filled text fields of mandatory questions
+        for q in [q1, q2, q3] where q.required == true {
+            guard let textAnswer = q.answerTextField.text
+                where !textAnswer.isEmpty else {
+                    self.displayAlert("Hello", message: "Please fill in all required fields :)", handler: nil)
+                    return
+            }
         }
-        guard let textAnswer2 = q2.answerTextField.text
-            where !textAnswer2.isEmpty else {
-                self.displayAlert("Hello", message: "Please fill in all required fields :)", handler: nil)
-                return
-        }
+        
         DatabaseController.updateText("where", question: q1)
         DatabaseController.updateText("activity", question: q2)
         DatabaseController.updateText("elseOptional", question: q3)
@@ -47,9 +45,9 @@ class SurveyPage1ViewController: UIViewController, AutoCompleteTextFieldDataSour
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
         // add questions to the stack view
-        q1 = TextQuestion.addToSurvey("Where were you?", key: "where", stackView: stackView, placeHolder: "Platt, Shanahan, Atwood, etc. ")
-        q2 = TextQuestion.addToSurvey("What was the main thing you were doing?", key: "activity", stackView: stackView, placeHolder: "Working, Class, etc. ")
-        q3 = TextQuestion.addToSurvey("(Optional) What else were you doing?", key: "elseOptional", stackView: stackView, placeHolder: "")
+        q1 = TextQuestion.addToSurvey("Where were you?", key: "where", stackView: stackView, placeHolder: "Platt, Shanahan, Atwood, etc. ", required: true)
+        q2 = TextQuestion.addToSurvey("What was the main thing you were doing?", key: "activity", stackView: stackView, placeHolder: "Working, Class, etc. ", required: true)
+        q3 = TextQuestion.addToSurvey("(Optional) What else were you doing?", key: "elseOptional", stackView: stackView, placeHolder: "", required: false)
         
         view.addSubview(stackView)
         

--- a/PaWPal/PaWPal/SurveyPage4ViewController.swift
+++ b/PaWPal/PaWPal/SurveyPage4ViewController.swift
@@ -39,7 +39,7 @@ class SurveyPage4ViewController: UIViewController {
         
         // add questions to view
         q1 = MultiCheckQuestion.addToSurvey("Who were you with? (Check all that apply)", key: "interaction", stackView: stackView)
-        q2 = TextQuestion.addToSurvey("How many hours have you been doing this activity?", key: "howLong", stackView: stackView, placeHolder: "")
+        q2 = TextQuestion.addToSurvey("How many hours have you been doing this activity?", key: "howLong", stackView: stackView, placeHolder: "", required: true)
         
         // for numerical answers
         q2.answerTextField.keyboardType = .NumberPad

--- a/PaWPal/PaWPal/SurveyPage4ViewController.swift
+++ b/PaWPal/PaWPal/SurveyPage4ViewController.swift
@@ -8,13 +8,9 @@
 
 import UIKit
 
-class SurveyPage4ViewController: UIViewController, AutoCompleteTextFieldDataSource, AutoCompleteTextFieldDelegate {
+class SurveyPage4ViewController: UIViewController {
     var q1: MultiCheckQuestion!
     var q2: TextQuestion!
-    
-    var activityLength: [String] = ["1 hour", "20 minutes"]
-    
-    var autoCompleteDictionary = [AutoCompleteTextField: [String]]()
     
     @IBAction func save(sender: UIButton) {
         DatabaseController.updateMultiCheck("interaction", question: q1)
@@ -22,10 +18,10 @@ class SurveyPage4ViewController: UIViewController, AutoCompleteTextFieldDataSour
     }
     
     @IBAction func next(sender: UIButton) {
-        // require that text fields be complete
+        // require numerical answer
         guard let textAnswer = q2.answerTextField.text
-            where !textAnswer.isEmpty else {
-                self.displayAlert("Hello", message: "Please fill in all required fields :)", handler: nil)
+            where Float(textAnswer) != nil else {
+                self.displayAlert("Hello", message: "Please enter a number :)", handler: nil)
                 return
         }
         save(sender)
@@ -43,7 +39,10 @@ class SurveyPage4ViewController: UIViewController, AutoCompleteTextFieldDataSour
         
         // add questions to view
         q1 = MultiCheckQuestion.addToSurvey("Who were you with? (Check all that apply)", key: "interaction", stackView: stackView)
-        q2 = TextQuestion.addToSurvey("How long had you been doing this activity for?", key: "howLong", stackView: stackView, placeHolder: "")
+        q2 = TextQuestion.addToSurvey("How many hours have you been doing this activity?", key: "howLong", stackView: stackView, placeHolder: "")
+        
+        // for numerical answers
+        q2.answerTextField.keyboardType = .NumberPad
         
         view.addSubview(stackView)
         
@@ -53,24 +52,14 @@ class SurveyPage4ViewController: UIViewController, AutoCompleteTextFieldDataSour
         let stackView_V = NSLayoutConstraint.constraintsWithVisualFormat("V:|-30-[stackView]-100-|", options: NSLayoutFormatOptions(rawValue:0), metrics: nil, views: viewsDictionary)
         view.addConstraints(stackView_H)
         view.addConstraints(stackView_V)
-        
-        autoCompleteDictionary = [q2.answerTextField: activityLength]
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         displayQuestions()
-        
-        q2.answerTextField.autoCompleteTextFieldDataSource = self
-        q2.answerTextField.showAutoCompleteButton(autoCompleteButtonViewMode: .WhileEditing)
     }
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
-    }
-    
-    func autoCompleteTextFieldDataSource(autoCompleteTextField: AutoCompleteTextField) -> [String] {
-        
-        return autoCompleteDictionary[autoCompleteTextField]!
     }
 }

--- a/PaWPal/PaWPal/SurveyPage6ViewController.swift
+++ b/PaWPal/PaWPal/SurveyPage6ViewController.swift
@@ -52,8 +52,8 @@ class SurveyPage6ViewController: UIViewController {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
         // add questions to view
-        q1 = TextQuestion.addToSurvey("(Optional) If you were feeling strong emotions, why?", key: "strongEmotionsOptional", stackView: stackView, placeHolder: "Describe")
-        q2 = TextQuestion.addToSurvey("(Optional) Was there something else on your mind?", key: "elseMindOptional", stackView: stackView, placeHolder: "Describe")
+        q1 = TextQuestion.addToSurvey("(Optional) If you were feeling strong emotions, why?", key: "strongEmotionsOptional", stackView: stackView, placeHolder: "Describe", required: false)
+        q2 = TextQuestion.addToSurvey("(Optional) Was there something else on your mind?", key: "elseMindOptional", stackView: stackView, placeHolder: "Describe", required: false)
         
         view.addSubview(stackView)
         

--- a/PaWPal/PaWPal/TextQuestion.swift
+++ b/PaWPal/PaWPal/TextQuestion.swift
@@ -12,12 +12,12 @@ import UIKit
 class TextQuestion: UIView {
     @IBOutlet weak var answerTextField: AutoCompleteTextField!
     @IBOutlet weak var promptLabel: UILabel!
-    public var autoCompleteStrings: [String]!
+    
+    internal var autoCompleteStrings: [String]!
+    internal var required: Bool!
     
     // add question to survey
-    static func addToSurvey(question: String, key: String, stackView: UIStackView, placeHolder: String) -> TextQuestion {
-        
-        
+    static func addToSurvey(question: String, key: String, stackView: UIStackView, placeHolder: String, required: Bool) -> TextQuestion {
         
         let textQuestion = NSBundle.mainBundle().loadNibNamed("TextQuestion", owner: self, options: nil).first as! TextQuestion
         
@@ -25,6 +25,8 @@ class TextQuestion: UIView {
         textQuestion.promptLabel.text = question
         textQuestion.answerTextField.text = (AppState.sharedInstance.surveyList[key] as? String)!
         textQuestion.answerTextField.attributedPlaceholder = NSAttributedString(string: placeHolder)
+        
+        textQuestion.required = required
 
         return textQuestion
         


### PR DESCRIPTION
@daking2014 @hmc-cs-asheppard @hmc-cs-dlan 

Requiring numerical answers is somewhat sketchy. So far, the number pad will pop up (on real phones, not simulator) and then we check for a valid Float value when the user clicks next.

Ideally, I would want to prevent typing in non-numeric characters, but xcode hates me